### PR TITLE
fix: add macCatalyst to LUA_USE_IOS platform list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -135,7 +135,7 @@ let package = Package(
             publicHeadersPath: "include",
             cSettings: {
                 var settings: [CSetting] = [
-                    .define("LUA_USE_IOS", .when(platforms: [.iOS, .visionOS, .watchOS, .tvOS])),
+                    .define("LUA_USE_IOS", .when(platforms: [.iOS, .macCatalyst, .visionOS, .watchOS, .tvOS])),
                     .define("LUA_USE_MACOSX", .when(platforms: [.macOS])),
                     .headerSearchPath(".")
                 ]


### PR DESCRIPTION
## Summary
- Add `.macCatalyst` to the `LUA_USE_IOS` define in `Package.swift`
- `system()` is unavailable on Mac Catalyst; this ensures `loslib.c` uses the no-op `l_system` macro

Closes #6